### PR TITLE
Move remote links to local links

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,11 +54,11 @@
         center: [0, 0],
         glyphs: "https://fonts.openmaptiles.org/{fontstack}/{range}.pbf",
         layers: americanaLayers,
-        sprite: "https://zelonewolf.github.io/maplibre-shield-rotation-sample/sprites/sprite",
+        sprite: "http://localhost:1776/sprites/sprite",
         bearing: 0,
         sources: {
           openmaptiles: {
-            url: "https://zelonewolf.github.io/maplibre-shield-rotation-sample/data/v3.json",
+            url: "http://localhost:8080/data/v3.json",
             type: "vector",
           },
           maptiler_attribution: {


### PR DESCRIPTION
Fixes #2 

Updates sprite and data file links to use local resources rather than remote HTTPS links which are failing Chrome CORS security settings.